### PR TITLE
[NEMO-678] Correct default path for executor configuration

### DIFF
--- a/conf/src/main/java/edu/snu/nemo/conf/JobConf.java
+++ b/conf/src/main/java/edu/snu/nemo/conf/JobConf.java
@@ -103,7 +103,7 @@ public final class JobConf extends ConfigurationModuleBuilder {
    * Path to the JSON file that specifies resource layout.
    */
   @NamedParameter(doc = "Path to the JSON file that specifies resources for executors", short_name = "executor_json",
-  default_value = "../resources/sample_executor_resources.json")
+  default_value = "examples/resources/sample_executor_resources.json")
   public final class ExecutorJsonPath implements Name<String> {
   }
 


### PR DESCRIPTION
This commit fixes default value for ExecutorJsonPath named parameter to point `sample_executor_resources.json`

Resolves #628